### PR TITLE
 Add Source.Ping(), include in InitSource() and tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/qntfy/frafka
 require (
 	github.com/confluentinc/confluent-kafka-go v0.11.6
 	github.com/gofrs/uuid v3.2.0+incompatible
+	github.com/pkg/errors v0.8.1
 	github.com/qntfy/frizzle v0.5.0
 	github.com/spf13/viper v1.2.1
 	github.com/stretchr/testify v1.2.2

--- a/integration_test.go
+++ b/integration_test.go
@@ -106,9 +106,8 @@ func (s *sourceTestSuite) SetupTest() {
 
 	var err error
 	s.src, err = frafka.InitSource(s.v)
-	if err != nil {
-		s.Error(err)
-		s.Fail("unable to initialize source")
+	if !s.Nil(err, "unable to initialize source") {
+		s.FailNow("unable to initialize source")
 	}
 	go func() {
 		for ev := range s.src.(frizzle.Eventer).Events() {
@@ -124,16 +123,11 @@ func (s *sourceTestSuite) TearDownTest() {
 func (s *sinkTestSuite) SetupTest() {
 	s.topic = kafkaTopic(s.T().Name())
 	err := s.cons.Subscribe(s.topic, nil)
-	if err != nil {
-		s.Error(err)
-		s.Fail("consumer unable to subscribe to topic")
-	}
+	s.Nil(err, "consumer unable to subscribe to topic")
 
 	s.sink, err = frafka.InitSink(s.v)
-	if err != nil {
-		s.Error(err)
-		s.Fail("unable to initialize sink")
-	}
+	s.Nil(err, "unable to initialize sink")
+
 	go func() {
 		for ev := range s.sink.(frizzle.Eventer).Events() {
 			s.T().Logf("async message: %s", ev)

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,6 +1,7 @@
 package frafka_test
 
 import (
+	"context"
 	"math/rand"
 	"strconv"
 	"strings"
@@ -24,6 +25,7 @@ const (
 type sourceTestSuite struct {
 	suite.Suite
 	prod  *kafka.Producer
+	admin *kafka.AdminClient
 	v     *viper.Viper
 	topic string
 	src   frizzle.Source
@@ -56,10 +58,18 @@ func TestKafkaSink(t *testing.T) {
 func (s *sourceTestSuite) SetupSuite() {
 	rand.Seed(time.Now().UnixNano())
 	brokers := loadKafkaTestENV()
+	cfg := &kafka.ConfigMap{
+		"bootstrap.servers":  brokers,
+		"session.timeout.ms": 6000,
+	}
 	var err error
-	s.prod, err = kafka.NewProducer(&kafka.ConfigMap{"bootstrap.servers": brokers})
-	if err != nil {
-		s.Error(err)
+	s.prod, err = kafka.NewProducer(cfg)
+	if !s.Nil(err) {
+		s.FailNow("unable to establish connection during test setup")
+	}
+
+	s.admin, err = kafka.NewAdminClient(cfg)
+	if !s.Nil(err) {
 		s.FailNow("unable to establish connection during test setup")
 	}
 
@@ -70,6 +80,7 @@ func (s *sourceTestSuite) SetupSuite() {
 
 func (s *sourceTestSuite) TearDownSuite() {
 	s.prod.Close()
+	s.admin.Close()
 }
 
 func (s *sinkTestSuite) SetupSuite() {
@@ -81,8 +92,7 @@ func (s *sinkTestSuite) SetupSuite() {
 		"group.id":          baseConsumerGroup,
 		"auto.offset.reset": "earliest",
 	})
-	if err != nil {
-		s.Error(err)
+	if !s.Nil(err) {
 		s.FailNow("unable to establish connection during test setup")
 	}
 
@@ -103,10 +113,21 @@ func kafkaTopic(s string) string {
 func (s *sourceTestSuite) SetupTest() {
 	s.topic = kafkaTopic(s.T().Name())
 	s.v.Set("kafka_topics", s.topic)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	results, err := s.admin.CreateTopics(ctx, []kafka.TopicSpecification{
+		kafka.TopicSpecification{
+			Topic:             s.topic,
+			NumPartitions:     1,
+			ReplicationFactor: 1,
+		},
+	})
+	if !s.Nil(err) || !s.Equal(kafka.ErrNoError, results[0].Error.Code()) {
+		s.FailNow("unable to create test topic")
+	}
 
-	var err error
 	s.src, err = frafka.InitSource(s.v)
-	if !s.Nil(err, "unable to initialize source") {
+	if !s.Nil(err) {
 		s.FailNow("unable to initialize source")
 	}
 	go func() {
@@ -123,10 +144,14 @@ func (s *sourceTestSuite) TearDownTest() {
 func (s *sinkTestSuite) SetupTest() {
 	s.topic = kafkaTopic(s.T().Name())
 	err := s.cons.Subscribe(s.topic, nil)
-	s.Nil(err, "consumer unable to subscribe to topic")
+	if !s.Nil(err) {
+		s.FailNow("consumer unable to subscribe to topic")
+	}
 
 	s.sink, err = frafka.InitSink(s.v)
-	s.Nil(err, "unable to initialize sink")
+	if !s.Nil(err) {
+		s.FailNow("unable to initialize sink")
+	}
 
 	go func() {
 		for ev := range s.sink.(frizzle.Eventer).Events() {

--- a/integration_test.go
+++ b/integration_test.go
@@ -238,6 +238,21 @@ func (s *sourceTestSuite) TestUnAckedAndFlush() {
 
 }
 
+func (s *sourceTestSuite) TestPing() {
+	kSrc := s.src.(*frafka.Source)
+	err := kSrc.Ping()
+	s.Nil(err, "expect successful Ping() for connected Source")
+
+	// ensure it fails on invalid broker
+	v := viper.New()
+	v.Set("kafka_brokers", "abc.def.ghij:9092")
+	v.Set("kafka_topics", s.topic)
+	v.Set("kafka_consumer_group", frizConsumerGroup)
+
+	_, err = frafka.InitSource(s.v)
+	s.Error(err, "expected error from invalid broker")
+}
+
 func (s *sourceTestSuite) TestStopAndClose() {
 	expectedValues := []string{"an unacked msg"}
 	s.T().Log(s.topic)


### PR DESCRIPTION
Currently a frafka Source will initialize without error even if the broker configuration is invalid or the specified input topics do not exist / are not available.

This adds a `Source.Ping()` method to test kafka cluster connectivity and that topics are available, and runs the method during `InitSource()` so that initialization will fail if the Source is mis-configured.

`Ping()` can also be used for periodic health checking in an application.