### PR TITLE
 Add support for Sink.Close() being called multiple times

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -219,6 +219,13 @@ func (s *sinkTestSuite) TestSend() {
 	s.Equal(expectedMessages, receivedMessages)
 }
 
+func (s *sinkTestSuite) TestCloseTwice() {
+	err := s.sink.Close()
+	s.Nil(err)
+	err = s.sink.Close()
+	s.Nil(err)
+}
+
 func (s *sourceTestSuite) produce(values []string) {
 	for _, m := range values {
 		s.prod.Produce(&kafka.Message{

--- a/sink.go
+++ b/sink.go
@@ -17,7 +17,7 @@ var (
 
 var (
 	// how long to wait for messages to flush
-	flushTimeoutMS = 30 * 1000
+	flushTimeoutMS = 10 * 1000
 )
 
 // Sink encapsulates a kafka producer for Sending Msgs
@@ -104,15 +104,18 @@ func (s *Sink) Send(m frizzle.Msg, topic string) error {
 // Close the Sink after flushing any Msgs not fully sent
 func (s *Sink) Close() error {
 	// Flush any messages still pending send
+	fmt.Println("flush producer")
 	if remaining := s.prod.Flush(flushTimeoutMS); remaining > 0 {
 		return fmt.Errorf("there are still %d messages which have not been delivered after %d milliseconds", remaining, flushTimeoutMS)
 	}
 	// tell deliveryReports() goroutine to finish
+	fmt.Println("close deliveryReports() loop")
 	s.quitChan <- 1
 	// wait for it to finish
 	<-s.doneChan
 	// stop event chan
 	close(s.evtChan)
+	fmt.Println("close producer")
 	s.prod.Close()
 	return nil
 }

--- a/source.go
+++ b/source.go
@@ -182,7 +182,6 @@ func (s *Source) Ping() error {
 // unAcked Msgs.
 func (s *Source) Close() error {
 	// confirm that consume() goroutine finished
-	fmt.Println("begin source close")
 	select {
 	case <-s.doneChan:
 	case <-time.After(stopCloseTimeout):
@@ -191,9 +190,7 @@ func (s *Source) Close() error {
 	if s.unAcked.Count() > 0 {
 		return frizzle.ErrUnackedMsgsRemain
 	}
-	fmt.Println("close channels")
 	close(s.msgChan)
 	close(s.evtChan)
-	fmt.Println("close consumer")
 	return s.cons.Close()
 }

--- a/source.go
+++ b/source.go
@@ -182,6 +182,7 @@ func (s *Source) Ping() error {
 // unAcked Msgs.
 func (s *Source) Close() error {
 	// confirm that consume() goroutine finished
+	fmt.Println("begin source close")
 	select {
 	case <-s.doneChan:
 	case <-time.After(stopCloseTimeout):
@@ -190,7 +191,9 @@ func (s *Source) Close() error {
 	if s.unAcked.Count() > 0 {
 		return frizzle.ErrUnackedMsgsRemain
 	}
+	fmt.Println("close channels")
 	close(s.msgChan)
 	close(s.evtChan)
+	fmt.Println("close consumer")
 	return s.cons.Close()
 }


### PR DESCRIPTION
See problems with common case where Sink is re-used as a frizzle FailSink. Currently call to `sink.Close()` will hang after a first attempt, halting app shutdown prematurely. With this fix, it will always return on subsequent calls to `Close()`.