### PR TITLE
Add `KAFKA_MAX_BUFFER_KB` to configure librdkafka buffer size

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ As of Go 1.11, frafka uses [go mod](https://github.com/golang/go/wiki/Modules) f
 
 ### Install librdkafka
 
-Frafka depends on C library `librdkafka` (>=`v0.11.4`). For Debian 9+ (which includes golang docker images),
+Frafka depends on C library `librdkafka` (>=`v0.11.6`). For Debian 9+ (which includes golang docker images),
 it has to be built from source. Fortunately, there's a script for that.
 
 ```sh

--- a/sink.go
+++ b/sink.go
@@ -105,14 +105,14 @@ func (s *Sink) Send(m frizzle.Msg, topic string) error {
 
 // Close the Sink after flushing any Msgs not fully sent
 func (s *Sink) Close() error {
-	// Flush any messages still pending send
-	if remaining := s.prod.Flush(flushTimeoutMS); remaining > 0 {
-		return fmt.Errorf("there are still %d messages which have not been delivered after %d milliseconds", remaining, flushTimeoutMS)
-	}
-
 	// check if already closed, return if so
 	if s.quitChan == nil {
 		return nil
+	}
+
+	// Flush any messages still pending send
+	if remaining := s.prod.Flush(flushTimeoutMS); remaining > 0 {
+		return fmt.Errorf("there are still %d messages which have not been delivered after %d milliseconds", remaining, flushTimeoutMS)
 	}
 
 	// tell deliveryReports() goroutine to finish if running


### PR DESCRIPTION
from README:
```
Corresponding librdkafka config values are `queue.buffering.max.kbytes` (Producer) and `queued.max.messages.kbytes`
(Consumer). Note that librdkafka creates one buffer each for the Producer (Sink) and for each topic+partition
being consumed by the source. E.g. with default 16MB default, if you are consuming from 4 partitions and also
producing then the theoretical max memory usage from the buffer would be `16*(4+1) = 80` MB.
```

The librdkafka default max buffer size is 1GB. We were seeing issues with hitting OOM crashes when running on a kafka backlog in memory constrained environments due to the large amount of buffering. After this fix, that no longer happens (if configured properly / with the new 16MB default).